### PR TITLE
Fixed string formatting to properly detect and delete existing namespace files

### DIFF
--- a/fibbingnode/southbound/namespaces.py
+++ b/fibbingnode/southbound/namespaces.py
@@ -28,7 +28,7 @@ class NetworkNamespace(object):
         self.create_ns()
 
     def create_ns(self):
-        if os.path.exists(NSDIR) and ' %s ' % self.name in os.listdir(NSDIR):
+        if os.path.exists(NSDIR) and '%s' % self.name in os.listdir(NSDIR):
             self.delete()
         err = _netns('add', self.name)
         if err != 0:


### PR DESCRIPTION
This prevents runtime errors, like the following, if a namespace file exists. The current function doesn't detect if an obsolete file is in the namespace directory because the string format is not correct.

Cannot create namespace file "/var/run/netns/ns*": File exists
[ERROR] create_ns: Failed to create namespace ns*